### PR TITLE
Increments gems

### DIFF
--- a/factory_bro.gemspec
+++ b/factory_bro.gemspec
@@ -9,8 +9,8 @@ Gem::Specification.new do |s|
   s.files       =  Dir['lib/**/*.rb']
   s.homepage    = 'https://github.com/nvreynolds/factory_bro'
 
-  s.add_dependency("pg", "~> 0.18.4")
-  s.add_dependency("faker", "~> 1.6.6")
+  s.add_dependency("pg", "~> 1.1.4")
+  s.add_dependency("faker", "~> 1.9.3")
 
   s.add_development_dependency("pry", "~> 0.10.4")
 end


### PR DESCRIPTION
Looking to avoid this error: 
```
Failures:

  1) Note Mentions when user types @ and string content matching user name should render user suggestions that match string
     Failure/Error: id = FactoryBro.exec('rtx', id_query).last.last

     PG::UnableToSend:
       extraneous data in "T" message
     # /usr/local/bundle/gems/factory_bro-0.0.7/lib/factory_bro.rb:45:in `exec'
     # /usr/local/bundle/gems/factory_bro-0.0.7/lib/factory_bro.rb:45:in `exec'
     # ./spec/helpers/search_helper.rb:36:in `reindex_resource'
     # ./spec/app/review_detail/notes_mentions_spec.rb:30:in `block (3 levels) in <top (required)>'
```

Tested with 20 test runs on this new pg version, and didn't run into this `PG:UnableToSend` error again :)